### PR TITLE
Add check for Chrome.app and Slack.app before install attempt

### DIFF
--- a/mac
+++ b/mac
@@ -79,14 +79,14 @@ if brew list | grep -Fq brew-cask; then
   brew uninstall --force brew-cask
 fi
 
-if brew cask list | grep -q "google-chrome"; then
+if brew cask list | grep -q "google-chrome" || [ -d "/Applications/Google Chrome.app" ] ; then
   fancy_echo "Chrome already installed, skipping"
 else
   brew cask install "google-chrome"
 fi
 
-if brew cask list | grep -q "slack"; then
-  fancy_echo "Slack already installed, skipping"
+if brew cask list | grep -q "slack" || [ -d "/Applications/Slack.app" ] ; then
+    fancy_echo "Slack already installed, skipping"
 else
   brew cask install "slack"
 fi


### PR DESCRIPTION
Some people already have Chrome and Slack installed when they run the script, so check for those before attempting to install them via `brew` as that would result in something like `Error: It seems there is already an App at '/Applications/Google Chrome.app'`.