### PR TITLE
brew: the sun has set on python2

### DIFF
--- a/mac
+++ b/mac
@@ -115,7 +115,7 @@ for i in "$@" ; do
         fi
         if [[ $i == "-backend" ]]  ; then
                 # Programming languages
-                brew install libyaml node python@2 python go rbenv ruby-build
+                brew install libyaml node python go rbenv ruby-build
                 sudo easy_install --upgrade pip
                 sudo pip install virtualenv
                 sudo pip install virtualenvwrapper


### PR DESCRIPTION
As [this notice](https://www.python.org/doc/sunset-python-2/) has beautifully put it, Python2 is no longer supported and patched. While using trying out the command to install backend stuff, `brew` showed an error. Thus, it's better to remove this altogether.